### PR TITLE
fix text wrapping of margin notes within code samples

### DIFF
--- a/scribble-lib/scribble/scribble.css
+++ b/scribble-lib/scribble/scribble.css
@@ -194,6 +194,7 @@ table td {
   font-size: 85%;
   border: 0.5em solid #F5F5DC;
   margin: 0 0 0 0;
+  white-space: normal; /* in case margin note is inside code sample */
 }
 
 .refcontent {


### PR DESCRIPTION
Code samples use `pre`, which will cascade into the margin note unless stopped.

Example of problem, reported by @mfelleisen:

![screen shot 2016-11-02 at 11 57 09 am](https://cloud.githubusercontent.com/assets/1425051/19973927/f614f630-a1a3-11e6-8a63-f74abb8b9411.png)
